### PR TITLE
Remove unused VS Code extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "vue.volar",
     "formulahendry.auto-close-tag",
-    "vue.vscode-typescript-vue-plugin",
     "bradlc.vscode-tailwindcss",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"


### PR DESCRIPTION
`vue.vscode-typescript-vue-plugin` was deprecated recently and all functionality moved in to `vue.volar`. It is no longer needed.